### PR TITLE
Add codebase overview with mermaid chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,52 @@ FlowVision/                   # Main application source
 content/                      # Images and assets
 ```
 
+## Codebase Overview
+
+**General Structure**
+
+- The project is a Windows Forms application targeting .NET 4.8. The solution (`FlowVision.sln`) loads a single project `FlowVision`.
+- `Program.cs` contains the entry point, which starts `Form1`.
+- Core logic lives under `FlowVision/lib/Classes/` and `FlowVision/lib/Plugins/`.
+- Plugins include modules such as `CMDPlugin`, `KeyboardPlugin`, `MousePlugin`, and screen-capture tools.
+- Configuration classes (`APIConfig`, `ToolConfig`, etc.) store user settings under `%APPDATA%\FlowVision\...` for persistence.
+
+**Important Components**
+
+- **Plugin System** – Explained above; it allows extending the toolset with keyboard/mouse automation, window management, PowerShell, etc. Plugins are stored in `FlowVision/lib/Plugins/`.
+- **ToolConfig** – Holds feature toggles and prompt templates. Default values and prompts are defined here.
+- **MultiAgentActioner** – Implements a multi-agent workflow using Semantic Kernel to coordinate a "coordinator," "planner," and "executor" agent.
+- **User Interface** – `Form1` presents a chat-like UI with text and speech input, uses `ThemeManager` for light/dark themes, and logs plugin operations using `PluginLogger`.
+
+**Getting Started**
+
+The README provides prerequisites, setup instructions, and folder layout.
+
+**Pointers for Next Steps**
+
+1. **Explore Plugin Development** – Each plugin class uses Semantic Kernel's `[KernelFunction]` attributes to expose commands. Creating new plugins or modifying existing ones is a good way to extend functionality.
+2. **Review Multi-Agent Logic** – `MultiAgentActioner` demonstrates coordinating multiple models/agents. Understanding its workflow helps when adapting the app to other LLMs or custom behaviors.
+3. **Understand Configuration Handling** – Look into how `ToolConfig` and `APIConfig` store settings in JSON files under `%APPDATA%`. Learning this pattern is important for customizing the tool for different environments.
+4. **UI Customization** – The `ThemeManager` and `MarkdownHelper` classes show how theming and markdown rendering are done. This is useful if you want to adapt the interface.
+5. **Security and Logging** – Read `SECURITY.md` for guidelines on reporting issues and inspect `PluginLogger` for how plugin usage is tracked.
+
+```mermaid
+graph TD
+    Program[Program.cs] --> Form1
+    Form1 --> PluginSystem
+    Form1 --> MultiAgentActioner
+    PluginSystem --> CMDPlugin
+    PluginSystem --> KeyboardPlugin
+    PluginSystem --> MousePlugin
+    PluginSystem --> ScreenCapturePlugin
+    MultiAgentActioner --> CoordinatorAgent
+    MultiAgentActioner --> PlannerAgent
+    MultiAgentActioner --> ExecutorAgent
+    APIConfig -.-> Form1
+    ToolConfig -.-> Form1
+```
+
+
 ## Example Use Cases
 - Control applications via natural language (e.g., "Open Excel and create a new spreadsheet")
 - Capture and process screenshots for documentation


### PR DESCRIPTION
## Summary
- include a newcomer-focused Codebase Overview section in the README
- add mermaid diagram showing relationships between key classes

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*