### PR TITLE
Add page content retrieval to Playwright plugin

### DIFF
--- a/FlowVision/lib/Plugins/PlaywrightPlugin.cs
+++ b/FlowVision/lib/Plugins/PlaywrightPlugin.cs
@@ -739,5 +739,57 @@ namespace FlowVision.lib.Plugins
                 return $"Error deleting session: {ex.Message}";
             }
         }
+
+        /// <summary>
+        /// Gets the full HTML content of the current page.
+        /// </summary>
+        [KernelFunction, Description("Gets the current page HTML content")]
+        public async Task<string> GetPageContent()
+        {
+            PluginLogger.LogPluginUsage("PlaywrightPlugin", "GetPageContent");
+
+            if (_page == null)
+            {
+                return "Error: Browser not launched. Call LaunchBrowser first.";
+            }
+
+            return await _page.ContentAsync();
+        }
+
+        /// <summary>
+        /// Retrieves text content from an element identified by a CSS selector.
+        /// </summary>
+        [KernelFunction, Description("Gets the text content of an element by CSS selector")]
+        public async Task<string> GetElementText(
+            [Description("CSS selector of the element")] string selector)
+        {
+            PluginLogger.LogPluginUsage("PlaywrightPlugin", "GetElementText", $"Selector: {selector}");
+
+            if (_page == null)
+            {
+                return "Error: Browser not launched. Call LaunchBrowser first.";
+            }
+
+            if (string.IsNullOrEmpty(selector))
+            {
+                return "Error: Selector cannot be empty";
+            }
+
+            try
+            {
+                var element = await _page.QuerySelectorAsync(selector);
+                if (element == null)
+                {
+                    return $"Error: Could not find element with selector: {selector}";
+                }
+
+                string text = await element.TextContentAsync();
+                return text ?? string.Empty;
+            }
+            catch (Exception ex)
+            {
+                return $"Error getting element text: {ex.Message}";
+            }
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Recursive Control supports a modular plugin system, allowing you to extend its c
 - **MousePlugin**: Automate mouse actions.
 - **ScreenCapturePlugin**: Capture screenshots.
 - **WindowSelectionPlugin**: Select and interact with application windows.
+- **PlaywrightPlugin**: Automate web browsing with functions like `GetPageContent` and `GetElementText` for retrieving page data.
 
 ## Folder Structure
 


### PR DESCRIPTION
## Summary
- add `GetPageContent` and `GetElementText` to `PlaywrightPlugin`
- document Playwright plugin retrieval functions in README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*