### PR TITLE
Add CloseBrowser to Playwright plugin

### DIFF
--- a/FlowVision/lib/Classes/ai/Actioner.cs
+++ b/FlowVision/lib/Classes/ai/Actioner.cs
@@ -154,8 +154,9 @@ namespace FlowVision.lib.Classes
 
                 if (toolConfig.EnablePlaywrightPlugin)
                 {
+                    // Expose browser automation utilities including CloseBrowser
                     builder.Plugins.AddFromType<PlaywrightPlugin>();
-                }   
+                }
 
                 actionerKernel = builder.Build();
                 actionerChat = actionerKernel.GetRequiredService<IChatCompletionService>();

--- a/FlowVision/lib/Classes/ai/MultiAgentActioner.cs
+++ b/FlowVision/lib/Classes/ai/MultiAgentActioner.cs
@@ -203,6 +203,7 @@ namespace FlowVision.lib.Classes
 
                 if (toolConfig.EnablePlaywrightPlugin)
                 {
+                    // Register Playwright plugin so the execution agent can call CloseBrowser
                     actionerBuilder.Plugins.AddFromType<PlaywrightPlugin>();
                 }
 

--- a/FlowVision/lib/Plugins/PlaywrightPlugin.cs
+++ b/FlowVision/lib/Plugins/PlaywrightPlugin.cs
@@ -739,5 +739,44 @@ namespace FlowVision.lib.Plugins
                 return $"Error deleting session: {ex.Message}";
             }
         }
+
+        /// <summary>
+        /// Closes the current browser instance and disposes all related resources.
+        /// </summary>
+        [KernelFunction, Description("Closes the active browser and releases resources")]
+        public async Task<string> CloseBrowser()
+        {
+            PluginLogger.LogPluginUsage("PlaywrightPlugin", "CloseBrowser");
+
+            try
+            {
+                if (_page != null)
+                {
+                    try { await _page.CloseAsync(); } catch { /* ignore */ }
+                    _page = null;
+                }
+
+                if (_context != null)
+                {
+                    try { await _context.CloseAsync(); } catch { /* ignore */ }
+                    _context = null;
+                }
+
+                if (_browser != null)
+                {
+                    try { await _browser.CloseAsync(); } catch { /* ignore */ }
+                    await _browser.DisposeAsync();
+                    _browser = null;
+                }
+
+                _initialized = false;
+
+                return "Browser closed successfully.";
+            }
+            catch (Exception ex)
+            {
+                return $"Error closing browser: {ex.Message}";
+            }
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Recursive Control supports a modular plugin system, allowing you to extend its c
 - **MousePlugin**: Automate mouse actions.
 - **ScreenCapturePlugin**: Capture screenshots.
 - **WindowSelectionPlugin**: Select and interact with application windows.
+- **PlaywrightPlugin**: Automate web browsers using Playwright. Use `LaunchBrowser` to start and `CloseBrowser` when finished.
 
 ## Folder Structure
 


### PR DESCRIPTION
## Summary
- add `CloseBrowser` method to Playwright plugin
- register Playwright plugin with a comment in Actioner and MultiAgentActioner
- document Playwright plugin usage in README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*