### PR TITLE
Add ExecuteScript to Playwright plugin

### DIFF
--- a/FlowVision/lib/Classes/ToolDescriptionGenerator.cs
+++ b/FlowVision/lib/Classes/ToolDescriptionGenerator.cs
@@ -38,8 +38,11 @@ namespace FlowVision.lib.Classes
             if (toolConfig.EnableMousePlugin) 
                 availableTools.Add(typeof(MousePlugin));
                 
-            if (toolConfig.EnableWindowSelectionPlugin) 
+            if (toolConfig.EnableWindowSelectionPlugin)
                 availableTools.Add(typeof(WindowSelectionPlugin));
+
+            if (toolConfig.EnablePlaywrightPlugin)
+                availableTools.Add(typeof(PlaywrightPlugin));
 
             if (availableTools.Count == 0)
                 return "No tools are currently available.";
@@ -143,6 +146,11 @@ namespace FlowVision.lib.Classes
                     return "get a list of all open windows";
                 if (methodName == "FocusWindow")
                     return "switch focus to a specific application window";
+            }
+            else if (toolType == typeof(PlaywrightPlugin))
+            {
+                if (methodName == "ExecuteScript")
+                    return "run JavaScript in the active browser page";
             }
 
             // Generic fallback based on method name

--- a/FlowVision/lib/Plugins/PlaywrightPlugin.cs
+++ b/FlowVision/lib/Plugins/PlaywrightPlugin.cs
@@ -739,5 +739,35 @@ namespace FlowVision.lib.Plugins
                 return $"Error deleting session: {ex.Message}";
             }
         }
+
+        /// <summary>
+        /// Executes custom JavaScript in the active page and returns the result.
+        /// </summary>
+        [KernelFunction, Description("Execute arbitrary JavaScript in the current page")]
+        public async Task<string> ExecuteScript(
+            [Description("JavaScript code to run")] string script)
+        {
+            PluginLogger.LogPluginUsage("PlaywrightPlugin", "ExecuteScript");
+
+            if (_page == null)
+            {
+                return "Error: Browser not launched. Call LaunchBrowser first.";
+            }
+
+            if (string.IsNullOrWhiteSpace(script))
+            {
+                return "Error: Script cannot be empty.";
+            }
+
+            try
+            {
+                var result = await _page.EvaluateAsync<string>(script);
+                return result ?? "";
+            }
+            catch (Exception ex)
+            {
+                return $"Error executing script: {ex.Message}";
+            }
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Recursive Control supports a modular plugin system, allowing you to extend its c
 - **MousePlugin**: Automate mouse actions.
 - **ScreenCapturePlugin**: Capture screenshots.
 - **WindowSelectionPlugin**: Select and interact with application windows.
+- **PlaywrightPlugin**: Automate web pages. Example:
+  1. `LaunchBrowser()` to open a page
+  2. `ExecuteScript("return document.title")` to run JavaScript
 
 ## Folder Structure
 


### PR DESCRIPTION
## Summary
- implement `ExecuteScript` in `PlaywrightPlugin`
- register Playwright plugin across Actioner classes
- describe Playwright plugin in tool listing
- document Playwright usage example

## Testing
- `dotnet build FlowVision.sln` *(fails: `dotnet` not found)*
- `dotnet test` *(fails: `dotnet` not found)*