### PR TITLE
Add dynamic tool prompt support

### DIFF
--- a/FlowVision.Tests/MultiAgentActionerTests.cs
+++ b/FlowVision.Tests/MultiAgentActionerTests.cs
@@ -1,6 +1,9 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using FlowVision.lib.Classes;
+using System;
 using System.Reflection;
+using System.IO;
+using System.Collections.Generic;
 
 namespace FlowVision.Tests
 {
@@ -36,6 +39,55 @@ namespace FlowVision.Tests
             string plan = "Hello there";
             string result = CallExtract(plan);
             Assert.IsNull(result);
+        }
+
+        private static string ConfigPath(string name)
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "FlowVision", "Config", $"{name}.json");
+        }
+
+        [TestMethod]
+        public void PlannerPrompt_ContainsTools_WhenDynamicPromptsEnabled()
+        {
+            var config = new ToolConfig();
+            config.DynamicToolPrompts = true;
+            config.EnableCMDPlugin = true; // ensure at least one tool
+            config.SaveConfig("toolsconfig");
+
+            var actioner = new MultiAgentActioner(null);
+            actioner.SetChatHistory(new List<LocalChatMessage>());
+
+            var field = typeof(MultiAgentActioner).GetField("plannerHistory", BindingFlags.NonPublic | BindingFlags.Instance);
+            var history = field.GetValue(actioner);
+            var enumerator = ((System.Collections.IEnumerable)history).GetEnumerator();
+            enumerator.MoveNext();
+            var first = enumerator.Current;
+            string content = (string)first.GetType().GetProperty("Content").GetValue(first);
+
+            Assert.IsTrue(content.Contains("You have access to the following tools"));
+        }
+
+        [TestMethod]
+        public void PlannerPrompt_OmitsTools_WhenDynamicPromptsDisabled()
+        {
+            var config = new ToolConfig();
+            config.DynamicToolPrompts = false;
+            config.EnableCMDPlugin = true;
+            config.SaveConfig("toolsconfig");
+
+            var actioner = new MultiAgentActioner(null);
+            actioner.SetChatHistory(new List<LocalChatMessage>());
+
+            var field = typeof(MultiAgentActioner).GetField("plannerHistory", BindingFlags.NonPublic | BindingFlags.Instance);
+            var history = field.GetValue(actioner);
+            var enumerator = ((System.Collections.IEnumerable)history).GetEnumerator();
+            enumerator.MoveNext();
+            var first = enumerator.Current;
+            string content = (string)first.GetType().GetProperty("Content").GetValue(first);
+
+            Assert.IsFalse(content.Contains("You have access to the following tools"));
         }
     }
 }

--- a/FlowVision/lib/Classes/ai/Actioner.cs
+++ b/FlowVision/lib/Classes/ai/Actioner.cs
@@ -82,6 +82,11 @@ namespace FlowVision.lib.Classes
             // Otherwise use the original implementation
             ToolConfig toolConfig = ToolConfig.LoadConfig(TOOL_CONFIG);
 
+            // Generate tool descriptions if dynamic prompts are enabled
+            string toolDescriptions = toolConfig.DynamicToolPrompts
+                ? "\n\n" + ToolDescriptionGenerator.GetToolDescriptions(toolConfig)
+                : string.Empty;
+
             // Notify that we're starting the action execution
             PluginLogger.NotifyTaskStart("Action Execution", "Processing your request");
             PluginLogger.StartLoadingIndicator("request");
@@ -89,7 +94,7 @@ namespace FlowVision.lib.Classes
             try
             {
                 // Add system message to actioner history
-                actionerHistory.AddSystemMessage(toolConfig.ActionerSystemPrompt);
+                actionerHistory.AddSystemMessage(toolConfig.ActionerSystemPrompt + toolDescriptions);
 
                 // Add action prompt to actioner history
                 actionerHistory.AddUserMessage(actionPrompt);

--- a/FlowVision/lib/Classes/ai/MultiAgentActioner.cs
+++ b/FlowVision/lib/Classes/ai/MultiAgentActioner.cs
@@ -78,24 +78,28 @@ namespace FlowVision.lib.Classes
             // Reload tool configuration to ensure we have the most recent settings
             toolConfig = ToolConfig.LoadConfig(TOOL_CONFIG);
 
+            // Build dynamic tool description segment if enabled
+            string toolDescriptions = toolConfig.DynamicToolPrompts
+                ? "\n\n" + ToolDescriptionGenerator.GetToolDescriptions(toolConfig)
+                : string.Empty;
+
             PluginLogger.NotifyTaskStart("Multi-Agent Action", "Planning and executing your request");
             PluginLogger.StartLoadingIndicator("coordination");
 
             try
             {
                 // Configure coordinator first
-                //coordinatorHistory.Clear();
-                coordinatorHistory.AddSystemMessage(toolConfig.CoordinatorSystemPrompt);
+                coordinatorHistory.AddSystemMessage(toolConfig.CoordinatorSystemPrompt + toolDescriptions);
                 coordinatorHistory.AddUserMessage(actionPrompt);
 
                 // Configure planner for later use
                 plannerHistory.Clear();
-                plannerHistory.AddSystemMessage(toolConfig.PlannerSystemPrompt);
+                plannerHistory.AddSystemMessage(toolConfig.PlannerSystemPrompt + toolDescriptions);
 
                 
                 // Configure actioner for later use
                 actionerHistory.Clear();
-                actionerHistory.AddSystemMessage(toolConfig.ActionerSystemPrompt);
+                actionerHistory.AddSystemMessage(toolConfig.ActionerSystemPrompt + toolDescriptions);
 
 
                 // Clear agent coordinator message history
@@ -448,11 +452,14 @@ namespace FlowVision.lib.Classes
         {
             // Set up coordinator history with system prompt
             coordinatorHistory.Clear();
-            coordinatorHistory.AddSystemMessage(toolConfig.CoordinatorSystemPrompt);
+            string toolDescriptions = toolConfig.DynamicToolPrompts
+                ? "\n\n" + ToolDescriptionGenerator.GetToolDescriptions(toolConfig)
+                : string.Empty;
+            coordinatorHistory.AddSystemMessage(toolConfig.CoordinatorSystemPrompt + toolDescriptions);
 
             // Set up planner history with system prompt
             plannerHistory.Clear();
-            plannerHistory.AddSystemMessage(toolConfig.PlannerSystemPrompt);
+            plannerHistory.AddSystemMessage(toolConfig.PlannerSystemPrompt + toolDescriptions);
 
             foreach (var message in chatHistory)
             {


### PR DESCRIPTION
## Summary
- append generated tool descriptions to system prompts when `DynamicToolPrompts` is enabled
- apply dynamic prompts in multi-agent actioner and actioner
- add tests for dynamic tool prompt behaviour

## Testing
- `dotnet test` *(fails: command not found)*