### PR TITLE
Add ExecuteScript browser automation method

### DIFF
--- a/FlowVision/lib/Classes/ai/Actioner.cs
+++ b/FlowVision/lib/Classes/ai/Actioner.cs
@@ -152,9 +152,9 @@ namespace FlowVision.lib.Classes
                     builder.Plugins.AddFromType<WindowSelectionPlugin>();
                 }
 
-                if (toolConfig.EnablePlaywrightPlugin)
-                {
-                    // Expose browser automation utilities including CloseBrowser
+               if (toolConfig.EnablePlaywrightPlugin)
+               {
+                    // Expose browser automation utilities including ExecuteScript and CloseBrowser
                     builder.Plugins.AddFromType<PlaywrightPlugin>();
                 }
 

--- a/FlowVision/lib/Classes/ai/MultiAgentActioner.cs
+++ b/FlowVision/lib/Classes/ai/MultiAgentActioner.cs
@@ -203,7 +203,7 @@ namespace FlowVision.lib.Classes
 
                 if (toolConfig.EnablePlaywrightPlugin)
                 {
-                    // Register Playwright plugin so the execution agent can call CloseBrowser
+                    // Register Playwright plugin so the execution agent can call ExecuteScript and CloseBrowser
                     actionerBuilder.Plugins.AddFromType<PlaywrightPlugin>();
                 }
 

--- a/FlowVision/lib/Plugins/PlaywrightPlugin.cs
+++ b/FlowVision/lib/Plugins/PlaywrightPlugin.cs
@@ -827,5 +827,35 @@ namespace FlowVision.lib.Plugins
                 return $"Error getting element text: {ex.Message}";
             }
         }
+
+        /// <summary>
+        /// Executes custom JavaScript in the current page and returns the result.
+        /// </summary>
+        [KernelFunction, Description("Executes a JavaScript snippet in the current page")]
+        public async Task<string> ExecuteScript(
+            [Description("JavaScript code to run")] string script)
+        {
+            PluginLogger.LogPluginUsage("PlaywrightPlugin", "ExecuteScript");
+
+            if (_page == null)
+            {
+                return "Error: Browser not launched. Call LaunchBrowser first.";
+            }
+
+            if (string.IsNullOrWhiteSpace(script))
+            {
+                return "Error: Script cannot be empty.";
+            }
+
+            try
+            {
+                string result = await _page.EvaluateAsync<string>(script);
+                return result ?? string.Empty;
+            }
+            catch (Exception ex)
+            {
+                return $"Error executing script: {ex.Message}";
+            }
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Recursive Control supports a modular plugin system, allowing you to extend its c
 - **MousePlugin**: Automate mouse actions.
 - **ScreenCapturePlugin**: Capture screenshots.
 - **WindowSelectionPlugin**: Select and interact with application windows.
-- **PlaywrightPlugin**: Automate web browsers using Playwright. Use `LaunchBrowser` to start and `CloseBrowser` when finished.
+- **PlaywrightPlugin**: Automate web browsers using Playwright. Use `LaunchBrowser` to start, `ExecuteScript` to run JavaScript, and `CloseBrowser` when finished.
 
 
 ## Folder Structure
@@ -132,6 +132,7 @@ graph TD
 - Control applications via natural language (e.g., "Open Excel and create a new spreadsheet")
 - Capture and process screenshots for documentation
 - Batch rename files or organize folders
+- Use PlaywrightPlugin to automate websites, e.g., `LaunchBrowser`, `NavigateTo`, then `ExecuteScript("return document.title;")` to read the page title
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- expose ExecuteScript in PlaywrightPlugin for running page JavaScript
- register Playwright tool (ExecuteScript and CloseBrowser) in Actioner and MultiAgentActioner
- document ExecuteScript in README with an example

## Testing
- `dotnet test` *(fails: command not found)*