### PR TITLE
Add remote control plugin and config options

### DIFF
--- a/FlowVision/ToolConfigForm.Designer.cs
+++ b/FlowVision/ToolConfigForm.Designer.cs
@@ -45,6 +45,9 @@
             this.chkWindowSelectionPlugin = new System.Windows.Forms.CheckBox();
             this.chkPlaywrightPlugin = new System.Windows.Forms.CheckBox();
             this.enablePluginLoggingCheckBox = new System.Windows.Forms.CheckBox();
+            this.chkEnableRemoteControl = new System.Windows.Forms.CheckBox();
+            this.numRemotePort = new System.Windows.Forms.NumericUpDown();
+            this.lblRemotePort = new System.Windows.Forms.Label();
             this.groupBoxSettings = new System.Windows.Forms.GroupBox();
             this.indicatorAutoInvoke = new System.Windows.Forms.PictureBox();
             this.indicatorMultiAgent = new System.Windows.Forms.PictureBox();
@@ -118,6 +121,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.indicatorPowerShell)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.indicatorCMD)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.indicatorPlaywright)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numRemotePort)).BeginInit();
             this.groupBoxSettings.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.indicatorAutoInvoke)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.indicatorMultiAgent)).BeginInit();
@@ -339,9 +343,53 @@
             this.enablePluginLoggingCheckBox.TabIndex = 7;
             this.enablePluginLoggingCheckBox.Text = "Log Plugin Usage";
             this.enablePluginLoggingCheckBox.UseVisualStyleBackColor = true;
-            // 
+            //
+            // chkEnableRemoteControl
+            //
+            this.chkEnableRemoteControl.AutoSize = true;
+            this.chkEnableRemoteControl.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chkEnableRemoteControl.Location = new System.Drawing.Point(23, 281);
+            this.chkEnableRemoteControl.Name = "chkEnableRemoteControl";
+            this.chkEnableRemoteControl.Size = new System.Drawing.Size(171, 23);
+            this.chkEnableRemoteControl.TabIndex = 8;
+            this.chkEnableRemoteControl.Text = "Enable Remote Control";
+            this.chkEnableRemoteControl.UseVisualStyleBackColor = true;
+            //
+            // lblRemotePort
+            //
+            this.lblRemotePort.AutoSize = true;
+            this.lblRemotePort.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblRemotePort.Location = new System.Drawing.Point(40, 310);
+            this.lblRemotePort.Name = "lblRemotePort";
+            this.lblRemotePort.Size = new System.Drawing.Size(82, 19);
+            this.lblRemotePort.TabIndex = 9;
+            this.lblRemotePort.Text = "Listen Port:";
+            //
+            // numRemotePort
+            //
+            this.numRemotePort.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.numRemotePort.Location = new System.Drawing.Point(128, 308);
+            this.numRemotePort.Maximum = new decimal(new int[] {
+            65535,
+            0,
+            0,
+            0});
+            this.numRemotePort.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.numRemotePort.Name = "numRemotePort";
+            this.numRemotePort.Size = new System.Drawing.Size(80, 25);
+            this.numRemotePort.TabIndex = 10;
+            this.numRemotePort.Value = new decimal(new int[] {
+            8085,
+            0,
+            0,
+            0});
+            //
             // groupBoxSettings
-            // 
+            //
             this.groupBoxSettings.Controls.Add(this.indicatorAutoInvoke);
             this.groupBoxSettings.Controls.Add(this.indicatorMultiAgent);
             this.groupBoxSettings.Controls.Add(this.chkMultiAgentMode);
@@ -626,6 +674,9 @@
             // 
             this.tabPlugins.Controls.Add(this.groupBoxPlugins);
             this.tabPlugins.Controls.Add(this.enablePluginLoggingCheckBox);
+            this.tabPlugins.Controls.Add(this.chkEnableRemoteControl);
+            this.tabPlugins.Controls.Add(this.lblRemotePort);
+            this.tabPlugins.Controls.Add(this.numRemotePort);
             this.tabPlugins.Location = new System.Drawing.Point(4, 26);
             this.tabPlugins.Name = "tabPlugins";
             this.tabPlugins.Padding = new System.Windows.Forms.Padding(3);
@@ -1118,6 +1169,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.indicatorPowerShell)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.indicatorCMD)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.indicatorPlaywright)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numRemotePort)).EndInit();
             this.groupBoxSettings.ResumeLayout(false);
             this.groupBoxSettings.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.indicatorAutoInvoke)).EndInit();
@@ -1174,6 +1226,9 @@
         private System.Windows.Forms.CheckBox chkWindowSelectionPlugin;
         private System.Windows.Forms.CheckBox chkPlaywrightPlugin;
         private System.Windows.Forms.CheckBox enablePluginLoggingCheckBox;
+        private System.Windows.Forms.CheckBox chkEnableRemoteControl;
+        private System.Windows.Forms.NumericUpDown numRemotePort;
+        private System.Windows.Forms.Label lblRemotePort;
         private System.Windows.Forms.GroupBox groupBoxSettings;
         private System.Windows.Forms.PictureBox indicatorAutoInvoke;
         private System.Windows.Forms.PictureBox indicatorMultiAgent;

--- a/FlowVision/ToolConfigForm.cs
+++ b/FlowVision/ToolConfigForm.cs
@@ -110,7 +110,9 @@ namespace FlowVision
                 { txtVoiceCommandPhrase, "Phrase to activate voice commands (e.g. 'Hey Assistant')" },
                 { cbTheme, "Choose light or dark theme for the interface" },
                 { cmbProfiles, "Load or save different configuration profiles" },
-                { chkPlaywrightPlugin, "Allow the AI assistant to automate browser interactions" }
+                { chkPlaywrightPlugin, "Allow the AI assistant to automate browser interactions" },
+                { chkEnableRemoteControl, "Enable remote HTTP control" },
+                { numRemotePort, "Port for remote control server" }
             };
 
             foreach (var kvp in tooltips)
@@ -310,6 +312,8 @@ namespace FlowVision
                 chkWindowSelectionPlugin.Checked = _toolConfig.EnableWindowSelectionPlugin;
                 enablePluginLoggingCheckBox.Checked = _toolConfig.EnablePluginLogging;
                 chkPlaywrightPlugin.Checked = _toolConfig.EnablePlaywrightPlugin;
+                chkEnableRemoteControl.Checked = _toolConfig.EnableRemoteControl;
+                numRemotePort.Value = _toolConfig.RemoteControlPort;
 
                 numTemperature.Value = (decimal)_toolConfig.Temperature;
                 chkAutoInvoke.Checked = _toolConfig.AutoInvokeKernelFunctions;
@@ -500,6 +504,8 @@ namespace FlowVision
             _toolConfig.EnableWindowSelectionPlugin = chkWindowSelectionPlugin.Checked;
             _toolConfig.EnablePluginLogging = enablePluginLoggingCheckBox.Checked;
             _toolConfig.EnablePlaywrightPlugin = chkPlaywrightPlugin.Checked;
+            _toolConfig.EnableRemoteControl = chkEnableRemoteControl.Checked;
+            _toolConfig.RemoteControlPort = (int)numRemotePort.Value;
 
             _toolConfig.Temperature = (double)numTemperature.Value;
             _toolConfig.AutoInvokeKernelFunctions = chkAutoInvoke.Checked;

--- a/FlowVision/lib/Classes/ToolConfig.cs
+++ b/FlowVision/lib/Classes/ToolConfig.cs
@@ -88,6 +88,10 @@ Focus on providing clear, helpful responses that address the user's needs comple
 
         public bool EnablePlaywrightPlugin { get; set; } = false; // Default to false for security
 
+        // Remote control settings
+        public bool EnableRemoteControl { get; set; } = false;
+        public int RemoteControlPort { get; set; } = 8085;
+
         public static string ConfigFilePath(string configName)
         {
             string configDir = Path.Combine(

--- a/FlowVision/lib/Classes/ai/Actioner.cs
+++ b/FlowVision/lib/Classes/ai/Actioner.cs
@@ -63,6 +63,14 @@ namespace FlowVision.lib.Classes
 
             // Initialize the multi-agent actioner with the same output handler
             multiAgentActioner = new MultiAgentActioner(outputHandler);
+
+            // Start remote control server if enabled
+            ToolConfig toolConfigInit = ToolConfig.LoadConfig(TOOL_CONFIG);
+            if (toolConfigInit.EnableRemoteControl)
+            {
+                RemoteControlPlugin.SetCommandHandler(async cmd => await ExecuteAction(cmd));
+                RemoteControlPlugin.StartServer(toolConfigInit.RemoteControlPort);
+            }
         }
 
         // Add method to toggle multi-agent mode
@@ -157,10 +165,15 @@ namespace FlowVision.lib.Classes
                     builder.Plugins.AddFromType<WindowSelectionPlugin>();
                 }
 
-               if (toolConfig.EnablePlaywrightPlugin)
-               {
+                if (toolConfig.EnablePlaywrightPlugin)
+                {
                     // Expose browser automation utilities including ExecuteScript and CloseBrowser
                     builder.Plugins.AddFromType<PlaywrightPlugin>();
+                }
+
+                if (toolConfig.EnableRemoteControl)
+                {
+                    builder.Plugins.AddFromType<RemoteControlPlugin>();
                 }
 
                 actionerKernel = builder.Build();

--- a/FlowVision/lib/Classes/ai/MultiAgentActioner.cs
+++ b/FlowVision/lib/Classes/ai/MultiAgentActioner.cs
@@ -211,6 +211,11 @@ namespace FlowVision.lib.Classes
                     actionerBuilder.Plugins.AddFromType<PlaywrightPlugin>();
                 }
 
+                if (toolConfig.EnableRemoteControl)
+                {
+                    actionerBuilder.Plugins.AddFromType<RemoteControlPlugin>();
+                }
+
                 actionerKernel = actionerBuilder.Build();
                 actionerChat = actionerKernel.GetRequiredService<IChatCompletionService>();
 

--- a/FlowVision/lib/Plugins/RemoteControlPlugin.cs
+++ b/FlowVision/lib/Plugins/RemoteControlPlugin.cs
@@ -1,0 +1,120 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FlowVision.lib.Classes;
+using Microsoft.SemanticKernel;
+using System.ComponentModel;
+
+namespace FlowVision.lib.Plugins
+{
+    /// <summary>
+    /// Simple HTTP server that forwards JSON commands to an assigned handler.
+    /// </summary>
+    public class RemoteControlPlugin : IDisposable
+    {
+        private static HttpListener _listener;
+        private static bool _running;
+        private static int _port;
+        private static Func<string, Task<string>> _commandHandler;
+
+        /// <summary>
+        /// Assign the delegate used to execute incoming commands.
+        /// </summary>
+        public static void SetCommandHandler(Func<string, Task<string>> handler)
+        {
+            _commandHandler = handler;
+        }
+
+        /// <summary>
+        /// Start listening on the configured port if not already running.
+        /// </summary>
+        public static void StartServer(int port)
+        {
+            if (_running)
+            {
+                return;
+            }
+
+            _port = port;
+            _listener = new HttpListener();
+            _listener.Prefixes.Add($"http://*:{port}/");
+            _listener.Start();
+            _running = true;
+            Task.Run(ListenLoop);
+        }
+
+        /// <summary>
+        /// Returns the status of the remote control server.
+        /// </summary>
+        [KernelFunction, Description("Get the status of the remote control server")]
+        public static string GetStatus() => _running ? $"Listening on {_port}" : "Stopped";
+
+        private static async Task ListenLoop()
+        {
+            while (_running)
+            {
+                try
+                {
+                    var context = await _listener.GetContextAsync();
+                    if (context.Request.HttpMethod != "POST")
+                    {
+                        context.Response.StatusCode = 404;
+                        context.Response.Close();
+                        continue;
+                    }
+
+                    string body;
+                    using (var reader = new StreamReader(context.Request.InputStream))
+                    {
+                        body = await reader.ReadToEndAsync();
+                    }
+
+                    string command = null;
+                    try
+                    {
+                        var doc = JsonDocument.Parse(body);
+                        if (doc.RootElement.TryGetProperty("command", out var cmdEl))
+                        {
+                            command = cmdEl.GetString();
+                        }
+                    }
+                    catch { }
+
+                    string result = string.Empty;
+                    if (!string.IsNullOrEmpty(command) && _commandHandler != null)
+                    {
+                        PluginLogger.LogPluginUsage("RemoteControlPlugin", "Command", command);
+                        result = await _commandHandler(command);
+                    }
+                    else
+                    {
+                        context.Response.StatusCode = 400;
+                        result = "Invalid command";
+                    }
+
+                    using var writer = new StreamWriter(context.Response.OutputStream);
+                    await writer.WriteAsync(result ?? string.Empty);
+                    context.Response.Close();
+                }
+                catch (Exception ex)
+                {
+                    PluginLogger.LogError("RemoteControl", "Listener", ex.Message);
+                }
+            }
+        }
+
+        public static void StopServer()
+        {
+            _running = false;
+            try { _listener?.Stop(); } catch { }
+            _listener = null;
+        }
+
+        public void Dispose()
+        {
+            StopServer();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Recursive Control supports a modular plugin system, allowing you to extend its c
 - **ScreenCapturePlugin**: Capture screenshots.
 - **WindowSelectionPlugin**: Select and interact with application windows.
 - **PlaywrightPlugin**: Automate web browsers using Playwright. Use `LaunchBrowser` to start, `ExecuteScript` to run JavaScript, and `CloseBrowser` when finished.
+- **RemoteControlPlugin**: Listen for HTTP JSON commands and forward them to the AI executor.
+  Start the server by enabling it in the ToolConfig. Send POST requests with `{ "command": "your text" }` to the configured port.
 
 
 ## Folder Structure


### PR DESCRIPTION
## Summary
- implement `RemoteControlPlugin` with lightweight HTTP server
- add remote control settings in `ToolConfig`
- expose enable and port options in `ToolConfigForm`
- start server when Actioner initializes and register plugin
- register plugin for multi-agent mode
- document new plugin in README

## Testing
- `dotnet build` *(fails: `dotnet` not found)*